### PR TITLE
Account for multiple screens when dragging maximized window

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,8 +101,9 @@ function fixDragRegionActions (win) {
         // and set the window position under the cursor
         if (win.isMaximizable() && win.isMaximized()) {
           const pointer = electron.screen.getCursorScreenPoint()
-          const workArea = electron.screen.getPrimaryDisplay().workArea
           const bounds = win.getNormalBounds ? win.getNormalBounds() : win.getBounds()
+          const whichScreen = electron.screen.getDisplayNearestPoint({x: bounds.x, y: bounds.y})
+          const workArea = whichScreen.workArea
           let clientX
           if (pointer.x - workArea.x < bounds.width * 0.8) {
             // the distance between the cursor and the left side of the work area is less than 4/5 window width


### PR DESCRIPTION
Hello, found a small bug with dragging down a window from maximized. If the user has multiple screens, it will always move the window to the primary display, which will separate the window from the mouse cursor if the initial drag starts from another screen.

This simply uses getDisplayNearestPoint to determine what screen the drag is starting on and to decide the workArea.